### PR TITLE
Add MS Windows (MinGW) support

### DIFF
--- a/include/rxterm/style.hpp
+++ b/include/rxterm/style.hpp
@@ -71,7 +71,7 @@ constexpr auto composeMod(X x, Xs...xs) {
 template<class X, class...Xs>
 constexpr auto computeMod(X x, Xs...xs) {
   auto const  r = composeMod(x, xs...);
-  return (r == "") ? "" : "\e[" + r + "m";
+  return (r == "") ? "" : "\033[" + r + "m";
 }
 
 FontColor isStyle(FontColor x) { return x; }

--- a/include/rxterm/terminal.hpp
+++ b/include/rxterm/terminal.hpp
@@ -5,8 +5,12 @@
 #include <algorithm>
 #include <string>
 
-#ifdef __WIN32
+#ifdef _WIN32
 #include <mutex>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
 #endif
 
 #include <rxterm/utils.hpp>
@@ -19,10 +23,10 @@ struct VirtualTerminal {
   std::string computeTransition(std::string const& next) const {
     if(buffer == next) return "";
     unsigned const n = std::count(buffer.begin(), buffer.end(), '\n');
-    return clearLines(n) + "\e[0m" + next;
+    return clearLines(n) + "\033[0m" + next;
   }
 
-  static std::string hide() { return "\e[0;8m"; }
+  static std::string hide() { return "\033[0;8m"; }
 
   VirtualTerminal flip(std::string const& next) const {
     auto const transition = computeTransition(next);
@@ -32,7 +36,7 @@ struct VirtualTerminal {
     return {next};
   }
 
-#ifdef __WIN32
+#ifdef _WIN32
   static std::once_flag initInstanceFlag;
   static DWORD initWindowsTerminal() {
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
@@ -57,7 +61,7 @@ struct VirtualTerminal {
 #endif
 };
 
-#ifdef __WIN32
+#ifdef _WIN32
 std::once_flag VirtualTerminal::initInstanceFlag;
 #endif
 }

--- a/include/rxterm/terminal.hpp
+++ b/include/rxterm/terminal.hpp
@@ -1,10 +1,14 @@
 #ifndef RXTERM_TERMINAL_HPP
 #define RXTERM_TERMINAL_HPP
 
-
 #include <iostream>
 #include <algorithm>
 #include <string>
+
+#ifdef __WIN32
+#include <mutex>
+#endif
+
 #include <rxterm/utils.hpp>
 
 namespace rxterm {
@@ -27,8 +31,35 @@ struct VirtualTerminal {
     std::flush(std::cout);
     return {next};
   }
+
+#ifdef __WIN32
+  static std::once_flag initInstanceFlag;
+  static DWORD initWindowsTerminal() {
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+  // Set output mode to handle virtual terminal sequences
+  HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+  if (hOut == INVALID_HANDLE_VALUE) return GetLastError();
+  DWORD dwMode = 0;
+  if (!GetConsoleMode(hOut, &dwMode)) return GetLastError();
+  dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+  if (!SetConsoleMode(hOut, dwMode)) return GetLastError();
+  return ERROR_SUCCESS;
+}
+
+  VirtualTerminal() {
+    std::call_once(initInstanceFlag, VirtualTerminal::initWindowsTerminal);
+  }
+  VirtualTerminal(const VirtualTerminal&) = default;
+  VirtualTerminal& operator=(const VirtualTerminal&) = default;
+  VirtualTerminal(const std::string &buf) : buffer{buf} {};
+#endif
 };
 
+#ifdef __WIN32
+std::once_flag VirtualTerminal::initInstanceFlag;
+#endif
 }
 
 #endif

--- a/include/rxterm/utils.hpp
+++ b/include/rxterm/utils.hpp
@@ -54,25 +54,25 @@ std::string repeat(unsigned n, std::string const& s) {
 }
 
 std::string clearBeforeCursor() {
-  return "\e[0K";
+  return "\033[0K";
 }
 
 std::string clearAfterCursor() {
-  return "\e[1K";
+  return "\033[1K";
 }
 
 std::string clearLine() {
-  return "\e[2K\r";
+  return "\033[2K\r";
 }
 
 
 std::string moveUp(unsigned n = 1) {
-  return "\e["+std::to_string(n) + "A\r";
+  return "\033["+std::to_string(n) + "A\r";
 }
 
 
 std::string clearLines(unsigned n = 1) {
-  return "\e[0m" + clearBeforeCursor() + ((n) ? repeat(n, clearLine() + moveUp()) : std::string(""));
+  return "\033[0m" + clearBeforeCursor() + ((n) ? repeat(n, clearLine() + moveUp()) : std::string(""));
 }
 
 template <typename T>


### PR DESCRIPTION
Added singlecall SetConsoleMode initialization code to the VirtualTermintal constructor. Tested on MinGW 8.1 compiler and Windows 10 native console (cmd.exe)