### PR TITLE
Terminal size detection

### DIFF
--- a/apps/main.cpp
+++ b/apps/main.cpp
@@ -1,12 +1,9 @@
-#include <string>
 #include <thread>
 #include <chrono>
-#include <memory>
 
 #include <rxterm/terminal.hpp>
 #include <rxterm/style.hpp>
 #include <rxterm/image.hpp>
-#include <rxterm/reflow.hpp>
 #include <rxterm/components/text.hpp>
 #include <rxterm/components/stacklayout.hpp>
 #include <rxterm/components/flowlayout.hpp>
@@ -16,7 +13,6 @@
 using namespace rxterm;
 
 auto renderToTerm = [](auto const& vt, unsigned const w, Component const& c) {
-  // TODO: get actual terminal width
   return vt.flip(c.render(w).toString());
 };
 
@@ -38,8 +34,10 @@ int main() {
     };
   };
 
+  auto w = VirtualTerminal::width();
+  if (!w) w = 80;
   for (int i = 0; i < 101; ++i) {
-    vt = renderToTerm(vt, 80, superProgressBar(0.01 * i, 0.02 * i, 0.03 * i));
+    vt = renderToTerm(vt, w, superProgressBar(0.01 * i, 0.02 * i, 0.03 * i));
     std::this_thread::sleep_for(200ms);
   }
 


### PR DESCRIPTION
Add static methods width() & height() to VirtualTerminal for detecting terminal window size in Linux & Windows. Tested in Windows 10 (cmd.exe, Windows Terminal, ConEmu) and WSL2 (Windows terminal).