### PR TITLE
Added CMake build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.10)
+project(rxterm)
+set(CMAKE_CXX_STANDARD 17)
+add_subdirectory(apps)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.10)
 project(rxterm)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 add_subdirectory(apps)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A C++ library for functional-reactive terminals. RxTerm is a lean alternative to
 
 The library builds with [Buckaroo](https://buckaroo.pm) and either [Buck](https://www.buckbuild.com) or [Bazel](https://bazel.build). It requires a C++ 14 compiler.
 
+### Buckaroo
+
 ```bash
 buckaroo install
 
@@ -17,8 +19,10 @@ buck build :rxterm
 
 # Bazel
 bazel build :rxterm
+```
 
-# CMake
+### CMake
+```bash
 mkdir build
 cd build
 cmake ..

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ buck build :rxterm
 
 # Bazel
 bazel build :rxterm
+
+# CMake
+mkdir build
+cd build
+cmake ..
+make
 ```
 
 To run the demo:
@@ -27,6 +33,10 @@ buck run :main
 
 # Bazel
 BAZEL_CXXOPTS="-std=c++14" bazel run :main
+
+# CMake (inside the build dir)
+cd apps/
+./rxterm-demo
 ```
 
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(rxterm-demo main.cpp)
+target_include_directories(rxterm-demo PUBLIC ${PROJECT_SOURCE_DIR}/include)


### PR DESCRIPTION
Hi there!

I had problems with running the **Buckaroo** build from my Raspberry Pi, so I prepared a **CMake** build file, which compiles the demo file in `apps/main.cpp`. 
Also provided build instructions in the `README.md` file.
You might consider merging it into your main branch so it's a bit easier to compile on Raspberry Pi devices.